### PR TITLE
Adding Windows Support

### DIFF
--- a/Context.sublime-menu
+++ b/Context.sublime-menu
@@ -1,8 +1,18 @@
 [
   {
-    "id" : "scsscompile",
-    "caption" : "Compile selected SCSS",
-    "command" : "scsscompile"
-  }
+  "caption": "Compile to CSS",
+  "id": "scsscompile",
+  "children":
+		[
+			{
+		    "caption" : "Compile selected SCSS",
+		    "command" : "scsscompile",
+		  },
+      {
+      	"caption": "Compile selected SCSS (minify)",
+      	"command": "scsscompile",
+      	"args": { "minify": "True" }
+      }   
+  	]
+	}
 ]
-

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Select the SCSS which you wish to compile, right click and select "Compile selec
 
 Open a Terminal window and run the following command:
 ```
-sudo gem install scss
+sudo gem install sass
 ```
 This script assumes that the `scss` binary is installed in the following location: `/usr/local/bin`.
 
@@ -23,5 +23,5 @@ Download and install the [Ruby installer](https://rubyinstaller.org/).
 
 Open an Admin Command or PowerShell window and run the following command:
 ```
-gem install scss
+gem install sass
 ```

--- a/README.md
+++ b/README.md
@@ -1,13 +1,27 @@
 # SCSS Compiler
 
-A Sublime Text 3 plugin which compiles the selected SCSS to CSS in your document.
+A Sublime Text 3 plugin which compiles the selected SCSS to CSS in your document window.
+This plugin depends on ruby being installed and the `scss` compiler binary being installed via ruby gems.
 
-# Installation
-This plugin depends on the 'python-scss' application, which can be installed using PIP.
-```
-pip install scss
-```
-This script also assumes that the `scss` binary is in the following location: `/usr/local/bin`.
+### Usage
+Select the SCSS which you wish to compile, right click and select "Compile selected SCSS to CSS". You may need to wait a few seconds for the compilier to do it's thing, and then your SCSS should then be transformed into CSS!
 
-# Usage
-Select the SCSS which you wish to compile, right click and select "Compile selected SCSS to CSS". You may need to wait a few seconds for Python to do it's thing, and then your SCSS should then be transformed into CSS!
+---
+# Installation on Linux & OS X 
+
+Open a Terminal window and run the following command:
+```
+sudo gem install scss
+```
+This script assumes that the `scss` binary is installed in the following location: `/usr/local/bin`.
+
+# Installation on Windows
+
+Download and install the [Ruby installer](https://rubyinstaller.org/).
+
+**Ensure the "Add Ruby executables to your PATH" is enabled during the installation process.**
+
+Open an Admin Command or PowerShell window and run the following command:
+```
+gem install scss
+```

--- a/scsscompile.py
+++ b/scsscompile.py
@@ -1,4 +1,4 @@
-import sublime, sublime_plugin
+import sublime, sublime_plugin, re
 from subprocess import Popen, PIPE, STDOUT
 from sys import platform
 
@@ -8,14 +8,18 @@ else:
     scss = '/usr/local/bin/scss'
 
 class scsscompileCommand(sublime_plugin.TextCommand):
-  def run(self, edit):
-    for region in self.view.sel():
+  def run(self, edit, minify = False):
+    for region in self.view.sel():  
             if not region.empty():
-                # Get the selected text
+                # Get the selected text  
                 s = self.view.substr(region)
                 p = Popen([scss], stdout=PIPE, stdin=PIPE, stderr=PIPE)
                 stdout_data = p.communicate(input=bytes(s, 'UTF-8'))[0]
                 # print(stdout_data)
                 stdout_data = str(stdout_data).replace('\\n', '\n').replace('\\r', '')
                 stdout_data = stdout_data[2:-2]
+                if minify:
+                    stdout_data = str(stdout_data).replace('\n', '').replace('\r', '').replace(' ', '')
+                    stdout_data = re.sub(r'\/\*.+\*\/', '', stdout_data)
+                    stdout_data = re.sub(r'\;\}', '}', stdout_data)
                 self.view.replace(edit, region, stdout_data)

--- a/scsscompile.py
+++ b/scsscompile.py
@@ -1,15 +1,21 @@
 import sublime, sublime_plugin
 from subprocess import Popen, PIPE, STDOUT
+from sys import platform
+
+if platform == 'win32':
+    scss = 'scss.bat'
+else:
+    scss = '/usr/local/bin/scss'
 
 class scsscompileCommand(sublime_plugin.TextCommand):
   def run(self, edit):
-    for region in self.view.sel():  
-            if not region.empty():  
-                # Get the selected text  
+    for region in self.view.sel():
+            if not region.empty():
+                # Get the selected text
                 s = self.view.substr(region)
-                p = Popen(['/usr/local/bin/scss'], stdout=PIPE, stdin=PIPE, stderr=PIPE)
+                p = Popen([scss], stdout=PIPE, stdin=PIPE, stderr=PIPE)
                 stdout_data = p.communicate(input=bytes(s, 'UTF-8'))[0]
                 # print(stdout_data)
-                stdout_data = str(stdout_data).replace('\\n', '\n')
-                stdout_data = stdout_data[2:-1]
+                stdout_data = str(stdout_data).replace('\\n', '\n').replace('\\r', '')
+                stdout_data = stdout_data[2:-2]
                 self.view.replace(edit, region, stdout_data)


### PR DESCRIPTION
These commits should allow for Windows support using the RubyInstaller for windows and the RubyGems package manager.

Additionally I've changed the installation instructions for OS X / Linux to also use the gem install method. I did this as on El Capitan using the pip install, I was getting Python errors when running the compiler. This  will also help keep the installation uniform between platforms.